### PR TITLE
Remove Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - "12"
-
-script:
-  - npm test # Test without sodium-native
-  - npm install --save sodium-native
-  - npm test # Test with sodium-native


### PR DESCRIPTION
We can now remove the Travis CI setup and use GitHub Actions to run tests on all thgree major platforms + Docker with a much better performance and a maximum of 20 parallel builds.