### PR TITLE
fix check for symmetric key

### DIFF
--- a/lib/sodiumplus.js
+++ b/lib/sodiumplus.js
@@ -667,7 +667,7 @@ class SodiumPlus {
      */
     async crypto_secretbox(plaintext, nonce, key) {
         await this.ensureLoaded();
-        if (key.isEd25519Key() || key.isEd25519Key()) {
+        if (key.isEd25519Key() || key.isX25519Key()) {
             throw new TypeError('Argument 3 must not be an asymmetric key');
         }
         if (!Buffer.isBuffer(nonce) || nonce.length !== 24) {
@@ -691,7 +691,7 @@ class SodiumPlus {
      */
     async crypto_secretbox_open(ciphertext, nonce, key) {
         await this.ensureLoaded();
-        if (key.isEd25519Key() || key.isEd25519Key()) {
+        if (key.isEd25519Key() || key.isX25519Key()) {
             throw new TypeError('Argument 3 must not be an asymmetric key');
         }
         if (!Buffer.isBuffer(ciphertext) || ciphertext.length < 16) {


### PR DESCRIPTION
crypto_secretbox was checking for `key.isEd25519Key() || key.isEd25519Key()`. I'm pretty confident `key.isEd25519Key() || key.isX25519Key()` better matches the intention.