### PR TITLE
Use the latest tag of the node image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
   build_latest:
     name: Node latest
     runs-on: ubuntu-latest
-    container: node:current
+    container: node:latest
     steps:
       - uses: actions/checkout@v1
       - name: install dependencies


### PR DESCRIPTION
Seems `current` points to something else now (12.13).

It was in some official documentation but I guess they deprecated this tag in favor of the latest tag.