### PR TITLE
Use _async functions from sodium-native for pwhash

### DIFF
--- a/lib/backend/sodiumnative.js
+++ b/lib/backend/sodiumnative.js
@@ -348,14 +348,22 @@ module.exports = class SodiumNativeBackend extends Backend {
      */
     async crypto_pwhash(length, password, salt, opslimit, memlimit, algorithm) {
         let hashed = Buffer.alloc(length, 0);
-        this.sodium.crypto_pwhash(
-            hashed,
-            await Util.toBuffer(password),
-            await Util.toBuffer(salt),
-            opslimit,
-            memlimit,
-            algorithm
-        );
+        const bufPass = await Util.toBuffer(password);
+        const bufSalt = await Util.toBuffer(salt);
+        await new Promise((resolve, reject) => {
+            this.sodium.crypto_pwhash_async(
+                hashed,
+                bufPass,
+                bufSalt,
+                opslimit,
+                memlimit,
+                algorithm,
+                (e, res) => {
+                    if (e) return reject(e);
+                    return resolve(res);
+                }
+            );
+        });
         return hashed;
     }
 
@@ -367,12 +375,19 @@ module.exports = class SodiumNativeBackend extends Backend {
      */
     async crypto_pwhash_str(password, opslimit, memlimit) {
         let hashed = Buffer.alloc(128, 0);
-        this.sodium.crypto_pwhash_str(
-            hashed,
-            await Util.toBuffer(password),
-            opslimit,
-            memlimit
-        );
+        const bufPass = await Util.toBuffer(password);
+        await new Promise((resolve, reject) => {
+            this.sodium.crypto_pwhash_str_async(
+                hashed,
+                bufPass,
+                opslimit,
+                memlimit,
+                (e, res) => {
+                    if (e) return reject(e);
+                    return resolve(res);
+                }
+            );
+        });
         return hashed.toString();
 
     }
@@ -385,10 +400,17 @@ module.exports = class SodiumNativeBackend extends Backend {
     async crypto_pwhash_str_verify(password, hash) {
         let allocated = Buffer.alloc(128, 0);
         (await Util.toBuffer(hash)).copy(allocated, 0, 0);
-        return this.sodium.crypto_pwhash_str_verify(
-            allocated,
-            await Util.toBuffer(password)
-        );
+        const bufPass = await Util.toBuffer(password);
+        return new Promise((resolve, reject) => {
+            this.sodium.crypto_pwhash_str_verify_async(
+                allocated,
+                bufPass,
+                (e, res) => {
+                    if (e) return reject(e);
+                    return resolve(res);
+                }
+            );
+        });
     }
 
     /**


### PR DESCRIPTION
sodium-native has _async implementation for these 3 functions, so it makes a lot of sense to use it. This offloads the current JS thread and is more efficient, especially when a lot of operations are done in bulk.