### PR TITLE
Align 'Encrypted Streams' API with OOP best practices to be more JavaScript friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 /package-lock.json
 *-tmp.js
+/nbproject

--- a/lib/sodiumplus.js
+++ b/lib/sodiumplus.js
@@ -769,7 +769,12 @@ class SodiumPlus {
         if (key.getLength() !== 32) {
             throw new SodiumError('crypto_secretstream keys must be 32 bytes long');
         }
-        return this.backend.crypto_secretstream_xchacha20poly1305_init_push(key);
+        let [state, header] = await this.backend.crypto_secretstream_xchacha20poly1305_init_push(key);
+        return Object.freeze({
+            header: header,
+            push: this.crypto_secretstream_xchacha20poly1305_push.bind(this, state),
+            rekey: this.crypto_secretstream_xchacha20poly1305_rekey.bind(this, state)
+        });
     }
 
     /**
@@ -791,7 +796,10 @@ class SodiumPlus {
         if (key.getLength() !== 32) {
             throw new SodiumError('crypto_secretstream keys must be 32 bytes long');
         }
-        return this.backend.crypto_secretstream_xchacha20poly1305_init_pull(header, key);
+        let state = await this.backend.crypto_secretstream_xchacha20poly1305_init_pull(header, key);
+        return Object.freeze({
+            pull: this.crypto_secretstream_xchacha20poly1305_pull.bind(this, state)
+        });
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sodium-plus",
-  "version": "1.0.0",
+  "version": "0.9.0",
   "description": "The Sodium Cryptography Library",
   "author": "Paragon Initiative Enterprises, LLC",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sodium-plus",
-  "version": "0.8.1",
+  "version": "1.0.0",
   "description": "The Sodium Cryptography Library",
   "author": "Paragon Initiative Enterprises, LLC",
   "license": "ISC",


### PR DESCRIPTION
Resolves #38 _Encrypted Streams API is not OOP-friendly_

1. Update `crypto_secretstream_xchacha20poly1305_init_push` method to return encryptor object with:
    * `header` read-only property
    * `push(message, ad = '', tag = 0)` method
    * `rekey` method
2. Update `crypto_secretstream_xchacha20poly1305_init_pull` method to return a new decryptor object with:
    * `pull(ciphertext, ad = '', tag = 0)` method
3. Bump version to 1.0.0 - this is NOT backward-compatible chage
4. Ignore NetBeans project files