### PR TITLE
Fix "Buffer is not defined" when using in browser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,10 @@
+/* istanbul ignore if */
+if (typeof (Buffer) === 'undefined') {
+    var Buffer = require('buffer/').Buffer;
+    // eslint-disable-next-line no-undef
+    window.Buffer = Buffer;
+}
+
 module.exports = {
     /**
      * This is only meant to be used for advanced users.

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -1,8 +1,4 @@
 const CryptographyKey = require('./cryptography-key');
-/* istanbul ignore if */
-if (typeof (Buffer) === 'undefined') {
-    let Buffer = require('buffer/').Buffer;
-}
 
 module.exports = class Backend {
     constructor() {

--- a/lib/backend/libsodium-wrappers.js
+++ b/lib/backend/libsodium-wrappers.js
@@ -5,10 +5,6 @@ const Polyfill = require('../polyfill');
 const Util = require('../util');
 const SodiumError = require('../sodium-error');
 const toBuffer = require('typedarray-to-buffer');
-/* istanbul ignore if */
-if (typeof (Buffer) === 'undefined') {
-    let Buffer = require('buffer/').Buffer;
-}
 
 /* istanbul ignore next */
 module.exports = class LibsodiumWrappersBackend extends Backend {

--- a/lib/backend/sodiumnative.js
+++ b/lib/backend/sodiumnative.js
@@ -12,10 +12,6 @@ const CryptographyKey = require('../cryptography-key');
 const SodiumError = require('../sodium-error');
 const Util = require('../util');
 const toBuffer = require('typedarray-to-buffer');
-/* istanbul ignore if */
-if (typeof (Buffer) === 'undefined') {
-    let Buffer = require('buffer/').Buffer;
-}
 
 /* istanbul ignore next */
 module.exports = class SodiumNativeBackend extends Backend {

--- a/lib/cryptography-key.js
+++ b/lib/cryptography-key.js
@@ -1,9 +1,5 @@
 "use strict";
 
-/* istanbul ignore if */
-if (typeof (Buffer) === 'undefined') {
-    let Buffer = require('buffer/').Buffer;
-}
 module.exports = class CryptographyKey {
     /**
      * Note: We use Object.defineProperty() to hide the buffer inside of the

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -4,11 +4,6 @@ const Poly1305 = require('poly1305-js');
 const Util = require('./util');
 const XSalsa20 = require('xsalsa20');
 
-/* istanbul ignore if */
-if (typeof (Buffer) === 'undefined') {
-    let Buffer = require('buffer/').Buffer;
-}
-
 module.exports = class SodiumPolyfill {
 
     /**

--- a/lib/sodiumplus.js
+++ b/lib/sodiumplus.js
@@ -9,11 +9,6 @@ const X25519PublicKey = require('./keytypes/x25519pk');
 const X25519SecretKey = require('./keytypes/x25519sk');
 const Util = require('./util');
 
-/* istanbul ignore if */
-if (typeof (Buffer) === 'undefined') {
-    let Buffer = require('buffer/').Buffer;
-}
-
 class SodiumPlus {
     constructor(backend) {
         /* istanbul ignore if */

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,10 +1,5 @@
 "use strict";
 
-/* istanbul ignore if */
-if (typeof (Buffer) === 'undefined') {
-    let Buffer = require('buffer/').Buffer;
-}
-
 const arrayToBuffer = require('typedarray-to-buffer');
 
 module.exports = class Util


### PR DESCRIPTION
This modification remove any usage of Buffer variable declaration in some files to center it only in "index.js"

Also, the previous `let` variable declaration was scoped to the `if` so `Buffer` was never declared in browsers.

I put it in `index.js` as a global variable in order to work and declare `Buffer` in the whole project where sodium-plus is installed.

Also resolves Issue #49 